### PR TITLE
Use "patch_font_unsafe" for TFM fonts again

### DIFF
--- a/src/luaotfload-loaders.lua
+++ b/src/luaotfload-loaders.lua
@@ -122,7 +122,7 @@ do
   local patch = function (specification, size, id)
     local fontdata = read (specification, size, id)
 ----if not fontdata then not_found_msg (specification, size, id) end
-    if type (fontdata) == "table" and fontdata.shared then
+    if type (fontdata) == "table" and fontdata.shared and fontdata.format ~= "unknown" then
       --- We need to test for the “shared” field here
       --- or else the fontspec capheight callback will
       --- operate on tfm fonts.

--- a/texmf/tex/luatex/luaotfload/luaotfload-loaders.lua
+++ b/texmf/tex/luatex/luaotfload/luaotfload-loaders.lua
@@ -122,7 +122,7 @@ do
   local patch = function (specification, size, id)
     local fontdata = read (specification, size, id)
 ----if not fontdata then not_found_msg (specification, size, id) end
-    if type (fontdata) == "table" and fontdata.shared then
+    if type (fontdata) == "table" and fontdata.shared and fontdata.format ~= "unknown" then
       --- We need to test for the “shared” field here
       --- or else the fontspec capheight callback will
       --- operate on tfm fonts.


### PR DESCRIPTION
This fixes #11. The current code assumed that `fontdata.shared` is `nil` for TFM fonts
which is no longer the case for current fontloaders.