### PR TITLE
Resolver refactoring, changes to resolver callback and ignoring tex files

### DIFF
--- a/doc/luaotfload-main.tex
+++ b/doc/luaotfload-main.tex
@@ -330,7 +330,8 @@ where \meta{prefix} is either \inlinecode{file:} or \inlinecode {name:}.\footnot
   This ensures full control over how a file is located.
   %
   For a working example see the
-  \hyperlink [test repo]{https://bitbucket.org/phg/lua-la-tex-tests/src/5f6a535d/pln-lookup-callback-1.tex}.
+  \hyperlink [test in the luaotfload
+  repo]{https://github.com/u-fischer/luaotfload/blob/master/testfiles/my-resolver.lvt}.
 }
 %
 It determines whether the font loader should interpret the request as

--- a/src/luaotfload-database.lua
+++ b/src/luaotfload-database.lua
@@ -686,8 +686,6 @@ end
 
 --doc]]--
 
-local dummy_findfile = resolvers.findfile -- from basics-gen
-
 --- string -> string * string * bool
 local lookup_font_file
 
@@ -700,7 +698,10 @@ lookup_font_file = function (filename)
     local found = lookup_filename (filename)
 
     if not found then
-        found = dummy_findfile(filename)
+        local type = file.suffix(filename)
+        if type ~= "" then
+            found = resolvers.findfile(filename, type)
+        end
     end
 
     if found then
@@ -748,7 +749,7 @@ local get_font_file = function (index)
     end
     local basename = entry.basename
     if entry.location == "texmf" then
-        local fullname = resolvers.findfile(basename)
+        local fullname = resolvers.findfile(basename, entry.format)
         if fullname then
             return true, fullname, entry.subfont
         end

--- a/src/luaotfload-features.lua
+++ b/src/luaotfload-features.lua
@@ -1124,21 +1124,6 @@ local import_values = {
     { "sub",    false },
 }
 
-local lookup_types = { "anon"  , "file", "kpse"
-                     , "my"    , "name", "path"
-                     , "combo"
-                     }
-
-local select_lookup = function (request)
-    for i=1, #lookup_types do
-        local lookup = lookup_types[i]
-        local value  = request[lookup]
-        if value then
-            return lookup, value
-        end
-    end
-end
-
 local supported = {
     b    = "b",
     i    = "i",
@@ -1212,9 +1197,9 @@ local handle_request = function (specification)
         return specification
     end
 
-    local lookup, name = select_lookup (request)
+    local lookup, name = request.lookup, request.name
     if lookup == "combo" then
-        return handle_combination (request.combo, specification)
+        return handle_combination (name, specification)
     end
 
     local features = specification.features
@@ -1235,12 +1220,6 @@ local handle_request = function (specification)
     request.features = apply_default_features(request.features)
 
     if name then
-        if lookup == "file" then
-            local suffix = file.suffix (name)
-            specification.forcedname = name
-            specification.forced     = suffix
-            name                     = file.removesuffix (name)
-        end
         specification.name     = name
         specification.lookup   = lookup or specification.lookup
     end

--- a/src/luaotfload-features.lua
+++ b/src/luaotfload-features.lua
@@ -1276,7 +1276,6 @@ local handle_request = function (specification)
     if request.features and request.features.mode
           and fonts.readers[request.features.mode] then
         specification.forced = request.features.mode
-        return specification
     end
 
     return specification

--- a/src/luaotfload-init.lua
+++ b/src/luaotfload-init.lua
@@ -722,10 +722,9 @@ local init_post_load_agl = function ()
 
   --doc]]--
 
-  local findfile  = resolvers.findfile
   local encodings = fonts.encodings
 
-  if not findfile or not encodings then
+  if not encodings then
     --- Might happen during refactoring; we continue graciously but in
     --- a somewhat defect state.
     logreport ("log", 0, "init",
@@ -750,11 +749,11 @@ local init_post_load_agl = function ()
       return nil
     end
 
-    local glyphlist = findfile "luaotfload-glyphlist.lua"
+    local glyphlist = kpsefind_file "luaotfload-glyphlist.lua"
     if glyphlist then
       logreport ("log", 1, "init", "loading the Adobe glyph list")
     else
-      glyphlist = findfile "font-age.lua"
+      glyphlist = kpsefind_file "font-age.lua"
       logreport ("both", 0, "init",
                  "loading the extended glyph list from ConTeXt")
     end

--- a/src/luaotfload-main.lua
+++ b/src/luaotfload-main.lua
@@ -65,11 +65,8 @@ else
     end
 end
 
-local info = status.list()
-
-if info["safer_option"] ~= 0 then
+if status.safer_option ~= 0 then
  texio.write_nl("term and log","luaotfload can't run with option --safer. Aborting")
- luaotfload.main = function () end
  error("safer_option used")
 end 
 

--- a/src/luaotfload-resolvers.lua
+++ b/src/luaotfload-resolvers.lua
@@ -283,7 +283,6 @@ return {
         end
         logreport ("log", 5, "resolvers", "installing font resolvers", name)
         local request_resolvers = fonts.definers.resolvers
-        table.print(request_resolvers)
         for k, _ in pairs(resolvers) do
             request_resolvers[k] = nil
         end
@@ -293,7 +292,6 @@ return {
             t[n] = wrapped
             return wrapped
         end})
-        table.print(request_resolvers)
         fonts.formats.ofm      = "type1"
         fonts.encodings        = fonts.encodings       or { }
         fonts.encodings.known  = fonts.encodings.known or { }

--- a/src/luaotfload-resolvers.lua
+++ b/src/luaotfload-resolvers.lua
@@ -73,20 +73,10 @@ local logreport           = luaotfload.log.report
 
 --doc]]--
 
-local resolve_file
-resolve_file = function (specification)
+local function resolve_file (specification)
     local name, _format, success = fonts.names.lookup_font_file (specification.name)
-    local suffix = filesuffix (name)
-    if not specification.forced and fonts.formats[suffix] then
-        specification.forced      = stringlower (suffix)
-        specification.forcedname  = fileremovesuffix (name)
-    else
-        specification.name = name
-    end
-    if success ~= true then
-        logreport ("log", 1, "resolve", "file lookup of %q unsuccessful", name)
-    end
-    return success
+    if success then return name end
+    logreport ("log", 1, "resolve", "file lookup of %q unsuccessful", name)
 end
 
 --[[doc--
@@ -99,25 +89,13 @@ end
 
 --doc]]--
 
-local resolve_path
-resolve_path = function (specification)
-    local name       = specification.name
-    local exists, _  = lfsisfile (name)
-    if not exists then -- resort to file: lookup
-        logreport ("log", 1, "resolve",
-                   "path lookup of %q unsuccessful, falling back to file:",
-                   name)
-        return resolve_file (specification)
-    end
-    local suffix = filesuffix (name)
-    if not specification.forced and fonts.formats [suffix] then
-        specification.forced      = stringlower (suffix)
-        specification.name        = fileremovesuffix (name)
-        specification.forcedname  = name
-    else
-        specification.name = name
-    end
-    return true
+local function resolve_path (specification)
+    local name = specification.name
+    if lfsisfile (name) then return name end
+    logreport ("log", 1, "resolve",
+               "path lookup of %q unsuccessful, falling back to file:",
+               name)
+    return resolve_file (specification)
 end
 
 --[[doc--
@@ -129,8 +107,7 @@ end
 --- fonts.names.resolvers.name -- Customized version of the
 --- generic name resolver.
 
-local resolve_name
-resolve_name = function (specification)
+local function resolve_name (specification)
     local resolver = fonts.names.lookup_font_name_cached
     if config.luaotfload.run.resolver == "normal" then
         resolver = fonts.names.lookup_font_name
@@ -140,13 +117,8 @@ resolve_name = function (specification)
         logreport ("log", 1, "resolve", "name lookup %q -> \"%s%s\"",
                    specification.name, resolved,
                    subfont and stringformat ("(%d)", subfont) or "")
-        specification.resolved   = resolved
-        specification.sub        = subfont
-        specification.forced     = specification.forced
-                                or stringlower (filesuffix (resolved) or "")
-        specification.forcedname = resolved
-        specification.name       = fileremovesuffix (resolved)
-        return true
+        specification.sub = subfont
+        return resolved
     end
     return resolve_file (specification)
 end
@@ -175,27 +147,22 @@ end
 
 --doc]]--
 
-local tex_formats = { "tfm", "ofm", "TFM", "OFM", }
+local tex_formats = { "tfm", "ofm" }
 
 local resolve_tex_format = function (specification)
     local name = specification.name
     for i=1, #tex_formats do
         local format = tex_formats [i]
-        local suffix = filesuffix (name)
-        if resolvers.findfile (name, format) then
-            local usename = suffix == format and fileremovesuffix (name) or name
-            specification.forcedname = file.addsuffix (usename, format)
-            specification.forced     = specification.forced or format
-----        specification.resolved   = name
-            return true
+        local resolved = resolvers.findfile(name, format)
+        if resolved then
+            return resolved, format
         end
     end
-    return false
 end
 
 local resolve_path_if_exists = function (specification)
     local spec = specification.specification
-    local exists, _void = lfsisfile (spec)
+    local exists = lfsisfile (spec)
     if exists then
         --- If this path is taken a file matching the specification
         --- literally was found. In this situation, Luaotfload is
@@ -204,10 +171,8 @@ local resolve_path_if_exists = function (specification)
         --- situation.
         logreport ("log", 1, "resolve",
                    "file %q exists, performing path lookup", spec)
-        specification.name = spec
-        return resolve_path (specification)
+        return spec
     end
-    return false
 end
 
 --[[doc--
@@ -215,7 +180,7 @@ end
 --doc]]--
 
 local resolve_my = function (specification)
-    luatexbase.call_callback ("luaotfload.resolve_font", specification)
+    return luatexbase.call_callback ("luaotfload.resolve_font", specification)
 end
 
 local resolve_methods = {
@@ -235,35 +200,25 @@ local resolve_sequence = function (seq, specification)
                        "step %d: invalid lookup method %q", i, id)
         else
             logreport ("both", 3, "resolve", "step %d: apply method %q (%s)", i, id, mth)
-            if mth (specification) == true then
+            local result = mth (specification)
+            if result then
                 logreport ("both", 3, "resolve",
-                           "%d: method %q resolved %q -> %s (%s).",
-                           i, id, specification.specification,
-                           specification.name,
-                           specification.forcedname)
-                return true
+                           "%d: method %q resolved %q -> %s.",
+                           i, id, specification.specification, result)
+                return result
             end
         end
     end
     logreport ("both", 0, "resolve",
                "sequence of %d lookups yielded nothing appropriate.", #seq)
-    return false
 end
 
 local default_anon_sequence = {
     "tex", "path", "name",
 }
 
-local resolve_anon
-resolve_anon = function (specification)
-    local seq = default_anon_sequence
-    if config and config.luaotfload then
-        local anonseq = config.luaotfload.run.anon_sequence
-        if anonseq and next (anonseq) then
-            seq = anonseq
-        end
-    end
-    return resolve_sequence (seq, specification)
+local function resolve_anon (specification)
+    return resolve_sequence (config.luaotfload.run.anon_sequence, specification)
 end
 
 --[[doc--
@@ -274,42 +229,56 @@ end
 
 --doc]]--
 
-local resolve_kpse
-resolve_kpse = function (specification)
+local function resolve_kpse (specification)
     local name       = specification.name
-    local suffix     = filesuffix (name)
-    if not specification.forced and suffix and fonts.formats[suffix] then
-        name = fileremovesuffix (name)
-        if resolvers.findfile (name, suffix) then
-            specification.forced       = stringlower (suffix)
-            specification.forcedname   = name
-            return true
-        end
+    local suffix     = stringlower (filesuffix (name))
+    if suffix and fonts.formats[suffix] then
+        local resolved = resolvers.findfile(name)
+        if resolved then return resolved end
     end
     for t, format in next, fonts.formats do --- brute force
-        if kpsefind_file (name, format) then
-            specification.forced = t
-            specification.name   = name
+        local resolved = kpsefind_file (name, format)
+        if resolved then return resolved, t end
+    end
+end
+
+local function wrap_resolver(resolver)
+    return function (specification)
+        local filename, forced = resolver(specification)
+        if filename then
+            specification.resolved = filename
+            specification.filename = filename
+            specification.name = filename
+            specification.forced = specification.forced or forced
+            if not specification.forced then
+                local suffix = stringlower (filesuffix (filename))
+                if suffix and fonts.formats[suffix] then
+                    specification.forced = suffix
+                end
+            end
+            if specification.forced then
+                specification.forcedname = filename
+            end
             return true
         end
+        return false
     end
-    return false
 end
 
 return {
     init = function ( )
         if luatexbase and luatexbase.create_callback then
             luatexbase.create_callback ("luaotfload.resolve_font",
-                                        "simple", function () end)
+                                        "exclusive", function () end)
         end
         logreport ("log", 5, "resolvers", "installing font resolvers", name)
         local request_resolvers = fonts.definers.resolvers
-        request_resolvers.file = resolve_file
-        request_resolvers.name = resolve_name
-        request_resolvers.anon = resolve_anon
-        request_resolvers.path = resolve_path
-        request_resolvers.kpse = resolve_kpse
-        request_resolvers.my   = resolve_my
+        request_resolvers.file = wrap_resolver(resolve_file)
+        request_resolvers.name = wrap_resolver(resolve_name)
+        request_resolvers.anon = wrap_resolver(resolve_anon)
+        request_resolvers.path = wrap_resolver(resolve_path)
+        request_resolvers.kpse = wrap_resolver(resolve_kpse)
+        request_resolvers.my   = wrap_resolver(resolve_my)
         fonts.formats.ofm      = "type1"
         fonts.encodings        = fonts.encodings       or { }
         fonts.encodings.known  = fonts.encodings.known or { }
@@ -318,4 +287,3 @@ return {
 }
 
 --- vim:ft=lua:ts=8:sw=4:et:tw=79
-

--- a/src/luaotfload-resolvers.lua
+++ b/src/luaotfload-resolvers.lua
@@ -200,12 +200,12 @@ local resolve_sequence = function (seq, specification)
                        "step %d: invalid lookup method %q", i, id)
         else
             logreport ("both", 3, "resolve", "step %d: apply method %q (%s)", i, id, mth)
-            local result = mth (specification)
+            local result, t = mth (specification)
             if result then
                 logreport ("both", 3, "resolve",
                            "%d: method %q resolved %q -> %s.",
                            i, id, specification.specification, result)
-                return result
+                return result, t
             end
         end
     end

--- a/src/luaotfload-resolvers.lua
+++ b/src/luaotfload-resolvers.lua
@@ -233,7 +233,7 @@ local function resolve_kpse (specification)
     local name       = specification.name
     local suffix     = stringlower (filesuffix (name))
     if suffix and fonts.formats[suffix] then
-        local resolved = resolvers.findfile(name)
+        local resolved = resolvers.findfile(name, suffix)
         if resolved then return resolved end
     end
     for t, format in next, fonts.formats do --- brute force

--- a/testfiles/my-resolver.lvt
+++ b/testfiles/my-resolver.lvt
@@ -1,0 +1,24 @@
+% !Mode:: "TeX:DE:UTF-8:Main"
+\input{regression-test}
+\documentclass{article}
+\usepackage{luacode}
+
+\begin{document}
+\START
+\showoutput
+
+\begin{luacode}
+  local my_fonts = {
+    rm = kpse.find_file("lmroman10-regular.otf", "opentype fonts"),
+    sf = kpse.find_file("lmsans10-regular.otf", "opentype fonts"),
+    dh = kpse.find_file("lmromandunh10-regular.otf", "opentype fonts"),
+  }
+  luatexbase.add_to_callback("luaotfload.resolve_font", function(spec)
+    return my_fonts[spec.name]
+  end, "luaotfload.test_resolver")
+\end{luacode}
+\font\myrm my:rm at 10pt
+\font\mysf my:sf at 10pt
+\font\mydh my:dh at 10pt
+\myrf Some \mysf nice \mydh fonts!
+\end{document}

--- a/testfiles/my-resolver.tlg
+++ b/testfiles/my-resolver.tlg
@@ -1,0 +1,59 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+Inserting `luaotfload.test_resolver' at position 1 in `luaotfload.resolve_font'.! Undefined control sequence.
+l. ...\myrf
+         Some \mysf nice \mydh fonts!
+The control sequence at the end of the top line
+of your error message was never \def'ed. If you have
+misspelled it (e.g., `\hobx'), type `I' and the correct
+spelling (e.g., `I\hbox'). Otherwise just continue,
+and I'll forget about whatever was undefined.
+Completed box being shipped out [1]
+\vbox(633.0+0.0)x407.0, direction TLT
+.\glue 16.0
+.\vbox(617.0+0.0)x345.0, shifted 62.0, direction TLT
+..\vbox(12.0+0.0)x345.0, glue set 12.0fil, direction TLT
+...\glue 0.0 plus 1.0fil
+...\hbox(0.0+0.0)x345.0, direction TLT
+..\glue 25.0
+..\glue(\lineskip) 0.0
+..\vbox(550.0+0.0)x345.0, glue set 539.94232fil, direction TLT
+...\write-{}
+...\glue(\topskip) 0.06
+...\hbox(9.94+0.22)x345.0, glue set 259.62fil, direction TLT
+....\localpar
+.....\localinterlinepenalty=0
+.....\localbrokenpenalty=0
+.....\localleftbox=null
+.....\localrightbox=null
+....\hbox(0.0+0.0)x15.0, direction TLT
+....\TU/lmr/m/n/10 S
+....\TU/lmr/m/n/10 o
+....\TU/lmr/m/n/10 m
+....\TU/lmr/m/n/10 e
+....\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+....\mysf n
+....\mysf i
+....\mysf c
+....\mysf e
+....\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+....\mydh f
+....\mydh o
+....\mydh n
+....\kern-0.28 (font)
+....\mydh t
+....\mydh s
+....\mydh !
+....\penalty 10000
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
+...\glue -0.22
+...\glue 0.0 plus 1.0fil
+...\glue 0.0
+...\glue 0.0 plus 0.0001fil
+..\glue(\baselineskip) 23.34
+..\hbox(6.66+0.0)x345.0, glue set 170.0fil, direction TLT
+...\glue 0.0 plus 1.0fil
+...\TU/lmr/m/n/10 1
+...\glue 0.0 plus 1.0fil
+(my-resolver.aux)

--- a/texmf/tex/luatex/luaotfload/luaotfload-database.lua
+++ b/texmf/tex/luatex/luaotfload/luaotfload-database.lua
@@ -686,8 +686,6 @@ end
 
 --doc]]--
 
-local dummy_findfile = resolvers.findfile -- from basics-gen
-
 --- string -> string * string * bool
 local lookup_font_file
 
@@ -700,7 +698,10 @@ lookup_font_file = function (filename)
     local found = lookup_filename (filename)
 
     if not found then
-        found = dummy_findfile(filename)
+        local type = file.suffix(filename)
+        if type ~= "" then
+            found = resolvers.findfile(filename, type)
+        end
     end
 
     if found then
@@ -748,7 +749,7 @@ local get_font_file = function (index)
     end
     local basename = entry.basename
     if entry.location == "texmf" then
-        local fullname = resolvers.findfile(basename)
+        local fullname = resolvers.findfile(basename, entry.format)
         if fullname then
             return true, fullname, entry.subfont
         end

--- a/texmf/tex/luatex/luaotfload/luaotfload-features.lua
+++ b/texmf/tex/luatex/luaotfload/luaotfload-features.lua
@@ -1124,21 +1124,6 @@ local import_values = {
     { "sub",    false },
 }
 
-local lookup_types = { "anon"  , "file", "kpse"
-                     , "my"    , "name", "path"
-                     , "combo"
-                     }
-
-local select_lookup = function (request)
-    for i=1, #lookup_types do
-        local lookup = lookup_types[i]
-        local value  = request[lookup]
-        if value then
-            return lookup, value
-        end
-    end
-end
-
 local supported = {
     b    = "b",
     i    = "i",
@@ -1212,9 +1197,9 @@ local handle_request = function (specification)
         return specification
     end
 
-    local lookup, name = select_lookup (request)
+    local lookup, name = request.lookup, request.name
     if lookup == "combo" then
-        return handle_combination (request.combo, specification)
+        return handle_combination (name, specification)
     end
 
     local features = specification.features
@@ -1235,12 +1220,6 @@ local handle_request = function (specification)
     request.features = apply_default_features(request.features)
 
     if name then
-        if lookup == "file" then
-            local suffix = file.suffix (name)
-            specification.forcedname = name
-            specification.forced     = suffix
-            name                     = file.removesuffix (name)
-        end
         specification.name     = name
         specification.lookup   = lookup or specification.lookup
     end

--- a/texmf/tex/luatex/luaotfload/luaotfload-features.lua
+++ b/texmf/tex/luatex/luaotfload/luaotfload-features.lua
@@ -1276,7 +1276,6 @@ local handle_request = function (specification)
     if request.features and request.features.mode
           and fonts.readers[request.features.mode] then
         specification.forced = request.features.mode
-        return specification
     end
 
     return specification

--- a/texmf/tex/luatex/luaotfload/luaotfload-init.lua
+++ b/texmf/tex/luatex/luaotfload/luaotfload-init.lua
@@ -722,10 +722,9 @@ local init_post_load_agl = function ()
 
   --doc]]--
 
-  local findfile  = resolvers.findfile
   local encodings = fonts.encodings
 
-  if not findfile or not encodings then
+  if not encodings then
     --- Might happen during refactoring; we continue graciously but in
     --- a somewhat defect state.
     logreport ("log", 0, "init",
@@ -750,11 +749,11 @@ local init_post_load_agl = function ()
       return nil
     end
 
-    local glyphlist = findfile "luaotfload-glyphlist.lua"
+    local glyphlist = kpsefind_file "luaotfload-glyphlist.lua"
     if glyphlist then
       logreport ("log", 1, "init", "loading the Adobe glyph list")
     else
-      glyphlist = findfile "font-age.lua"
+      glyphlist = kpsefind_file "font-age.lua"
       logreport ("both", 0, "init",
                  "loading the extended glyph list from ConTeXt")
     end

--- a/texmf/tex/luatex/luaotfload/luaotfload-main.lua
+++ b/texmf/tex/luatex/luaotfload/luaotfload-main.lua
@@ -65,11 +65,8 @@ else
     end
 end
 
-local info = status.list()
-
-if info["safer_option"] ~= 0 then
+if status.safer_option ~= 0 then
  texio.write_nl("term and log","luaotfload can't run with option --safer. Aborting")
- luaotfload.main = function () end
  error("safer_option used")
 end 
 

--- a/texmf/tex/luatex/luaotfload/luaotfload-resolvers.lua
+++ b/texmf/tex/luatex/luaotfload/luaotfload-resolvers.lua
@@ -283,7 +283,6 @@ return {
         end
         logreport ("log", 5, "resolvers", "installing font resolvers", name)
         local request_resolvers = fonts.definers.resolvers
-        table.print(request_resolvers)
         for k, _ in pairs(resolvers) do
             request_resolvers[k] = nil
         end
@@ -293,7 +292,6 @@ return {
             t[n] = wrapped
             return wrapped
         end})
-        table.print(request_resolvers)
         fonts.formats.ofm      = "type1"
         fonts.encodings        = fonts.encodings       or { }
         fonts.encodings.known  = fonts.encodings.known or { }

--- a/texmf/tex/luatex/luaotfload/luaotfload-resolvers.lua
+++ b/texmf/tex/luatex/luaotfload/luaotfload-resolvers.lua
@@ -73,20 +73,10 @@ local logreport           = luaotfload.log.report
 
 --doc]]--
 
-local resolve_file
-resolve_file = function (specification)
+local function resolve_file (specification)
     local name, _format, success = fonts.names.lookup_font_file (specification.name)
-    local suffix = filesuffix (name)
-    if not specification.forced and fonts.formats[suffix] then
-        specification.forced      = stringlower (suffix)
-        specification.forcedname  = fileremovesuffix (name)
-    else
-        specification.name = name
-    end
-    if success ~= true then
-        logreport ("log", 1, "resolve", "file lookup of %q unsuccessful", name)
-    end
-    return success
+    if success then return name end
+    logreport ("log", 1, "resolve", "file lookup of %q unsuccessful", name)
 end
 
 --[[doc--
@@ -99,25 +89,13 @@ end
 
 --doc]]--
 
-local resolve_path
-resolve_path = function (specification)
-    local name       = specification.name
-    local exists, _  = lfsisfile (name)
-    if not exists then -- resort to file: lookup
-        logreport ("log", 1, "resolve",
-                   "path lookup of %q unsuccessful, falling back to file:",
-                   name)
-        return resolve_file (specification)
-    end
-    local suffix = filesuffix (name)
-    if not specification.forced and fonts.formats [suffix] then
-        specification.forced      = stringlower (suffix)
-        specification.name        = fileremovesuffix (name)
-        specification.forcedname  = name
-    else
-        specification.name = name
-    end
-    return true
+local function resolve_path (specification)
+    local name = specification.name
+    if lfsisfile (name) then return name end
+    logreport ("log", 1, "resolve",
+               "path lookup of %q unsuccessful, falling back to file:",
+               name)
+    return resolve_file (specification)
 end
 
 --[[doc--
@@ -129,8 +107,7 @@ end
 --- fonts.names.resolvers.name -- Customized version of the
 --- generic name resolver.
 
-local resolve_name
-resolve_name = function (specification)
+local function resolve_name (specification)
     local resolver = fonts.names.lookup_font_name_cached
     if config.luaotfload.run.resolver == "normal" then
         resolver = fonts.names.lookup_font_name
@@ -140,13 +117,8 @@ resolve_name = function (specification)
         logreport ("log", 1, "resolve", "name lookup %q -> \"%s%s\"",
                    specification.name, resolved,
                    subfont and stringformat ("(%d)", subfont) or "")
-        specification.resolved   = resolved
-        specification.sub        = subfont
-        specification.forced     = specification.forced
-                                or stringlower (filesuffix (resolved) or "")
-        specification.forcedname = resolved
-        specification.name       = fileremovesuffix (resolved)
-        return true
+        specification.sub = subfont
+        return resolved
     end
     return resolve_file (specification)
 end
@@ -175,27 +147,22 @@ end
 
 --doc]]--
 
-local tex_formats = { "tfm", "ofm", "TFM", "OFM", }
+local tex_formats = { "tfm", "ofm" }
 
 local resolve_tex_format = function (specification)
     local name = specification.name
     for i=1, #tex_formats do
         local format = tex_formats [i]
-        local suffix = filesuffix (name)
-        if resolvers.findfile (name, format) then
-            local usename = suffix == format and fileremovesuffix (name) or name
-            specification.forcedname = file.addsuffix (usename, format)
-            specification.forced     = specification.forced or format
-----        specification.resolved   = name
-            return true
+        local resolved = resolvers.findfile(name, format)
+        if resolved then
+            return resolved, format
         end
     end
-    return false
 end
 
 local resolve_path_if_exists = function (specification)
     local spec = specification.specification
-    local exists, _void = lfsisfile (spec)
+    local exists = lfsisfile (spec)
     if exists then
         --- If this path is taken a file matching the specification
         --- literally was found. In this situation, Luaotfload is
@@ -204,10 +171,8 @@ local resolve_path_if_exists = function (specification)
         --- situation.
         logreport ("log", 1, "resolve",
                    "file %q exists, performing path lookup", spec)
-        specification.name = spec
-        return resolve_path (specification)
+        return spec
     end
-    return false
 end
 
 --[[doc--
@@ -215,7 +180,7 @@ end
 --doc]]--
 
 local resolve_my = function (specification)
-    luatexbase.call_callback ("luaotfload.resolve_font", specification)
+    return luatexbase.call_callback ("luaotfload.resolve_font", specification)
 end
 
 local resolve_methods = {
@@ -235,35 +200,25 @@ local resolve_sequence = function (seq, specification)
                        "step %d: invalid lookup method %q", i, id)
         else
             logreport ("both", 3, "resolve", "step %d: apply method %q (%s)", i, id, mth)
-            if mth (specification) == true then
+            local result = mth (specification)
+            if result then
                 logreport ("both", 3, "resolve",
-                           "%d: method %q resolved %q -> %s (%s).",
-                           i, id, specification.specification,
-                           specification.name,
-                           specification.forcedname)
-                return true
+                           "%d: method %q resolved %q -> %s.",
+                           i, id, specification.specification, result)
+                return result
             end
         end
     end
     logreport ("both", 0, "resolve",
                "sequence of %d lookups yielded nothing appropriate.", #seq)
-    return false
 end
 
 local default_anon_sequence = {
     "tex", "path", "name",
 }
 
-local resolve_anon
-resolve_anon = function (specification)
-    local seq = default_anon_sequence
-    if config and config.luaotfload then
-        local anonseq = config.luaotfload.run.anon_sequence
-        if anonseq and next (anonseq) then
-            seq = anonseq
-        end
-    end
-    return resolve_sequence (seq, specification)
+local function resolve_anon (specification)
+    return resolve_sequence (config.luaotfload.run.anon_sequence, specification)
 end
 
 --[[doc--
@@ -274,42 +229,56 @@ end
 
 --doc]]--
 
-local resolve_kpse
-resolve_kpse = function (specification)
+local function resolve_kpse (specification)
     local name       = specification.name
-    local suffix     = filesuffix (name)
-    if not specification.forced and suffix and fonts.formats[suffix] then
-        name = fileremovesuffix (name)
-        if resolvers.findfile (name, suffix) then
-            specification.forced       = stringlower (suffix)
-            specification.forcedname   = name
-            return true
-        end
+    local suffix     = stringlower (filesuffix (name))
+    if suffix and fonts.formats[suffix] then
+        local resolved = resolvers.findfile(name)
+        if resolved then return resolved end
     end
     for t, format in next, fonts.formats do --- brute force
-        if kpsefind_file (name, format) then
-            specification.forced = t
-            specification.name   = name
+        local resolved = kpsefind_file (name, format)
+        if resolved then return resolved, t end
+    end
+end
+
+local function wrap_resolver(resolver)
+    return function (specification)
+        local filename, forced = resolver(specification)
+        if filename then
+            specification.resolved = filename
+            specification.filename = filename
+            specification.name = filename
+            specification.forced = specification.forced or forced
+            if not specification.forced then
+                local suffix = stringlower (filesuffix (filename))
+                if suffix and fonts.formats[suffix] then
+                    specification.forced = suffix
+                end
+            end
+            if specification.forced then
+                specification.forcedname = filename
+            end
             return true
         end
+        return false
     end
-    return false
 end
 
 return {
     init = function ( )
         if luatexbase and luatexbase.create_callback then
             luatexbase.create_callback ("luaotfload.resolve_font",
-                                        "simple", function () end)
+                                        "exclusive", function () end)
         end
         logreport ("log", 5, "resolvers", "installing font resolvers", name)
         local request_resolvers = fonts.definers.resolvers
-        request_resolvers.file = resolve_file
-        request_resolvers.name = resolve_name
-        request_resolvers.anon = resolve_anon
-        request_resolvers.path = resolve_path
-        request_resolvers.kpse = resolve_kpse
-        request_resolvers.my   = resolve_my
+        request_resolvers.file = wrap_resolver(resolve_file)
+        request_resolvers.name = wrap_resolver(resolve_name)
+        request_resolvers.anon = wrap_resolver(resolve_anon)
+        request_resolvers.path = wrap_resolver(resolve_path)
+        request_resolvers.kpse = wrap_resolver(resolve_kpse)
+        request_resolvers.my   = wrap_resolver(resolve_my)
         fonts.formats.ofm      = "type1"
         fonts.encodings        = fonts.encodings       or { }
         fonts.encodings.known  = fonts.encodings.known or { }
@@ -318,4 +287,3 @@ return {
 }
 
 --- vim:ft=lua:ts=8:sw=4:et:tw=79
-

--- a/texmf/tex/luatex/luaotfload/luaotfload-resolvers.lua
+++ b/texmf/tex/luatex/luaotfload/luaotfload-resolvers.lua
@@ -200,12 +200,12 @@ local resolve_sequence = function (seq, specification)
                        "step %d: invalid lookup method %q", i, id)
         else
             logreport ("both", 3, "resolve", "step %d: apply method %q (%s)", i, id, mth)
-            local result = mth (specification)
+            local result, t = mth (specification)
             if result then
                 logreport ("both", 3, "resolve",
                            "%d: method %q resolved %q -> %s.",
                            i, id, specification.specification, result)
-                return result
+                return result, t
             end
         end
     end

--- a/texmf/tex/luatex/luaotfload/luaotfload-resolvers.lua
+++ b/texmf/tex/luatex/luaotfload/luaotfload-resolvers.lua
@@ -233,7 +233,7 @@ local function resolve_kpse (specification)
     local name       = specification.name
     local suffix     = stringlower (filesuffix (name))
     if suffix and fonts.formats[suffix] then
-        local resolved = resolvers.findfile(name)
+        local resolved = resolvers.findfile(name, suffix)
         if resolved then return resolved end
     end
     for t, format in next, fonts.formats do --- brute force


### PR DESCRIPTION
This changes the resolver code to always return the font in the same field and making new resolvers easier to implement.
By saving lookup results in the resolver this should also give a slight speed advantage and it fixes problems with weird fontnames (especially for fonts with duplicated extensions)

One breaking change:
The `luaotfload.resolve_font` callback is changed from `simple` to `exclusive` and the interface changes. The new callback just has to return the resolved fontname instead of changing multiple fields in the passed table.

Also fixes the problem with `tex` files detected as fonts.