### PR TITLE
Access node functions in luaotfload-letterspace directly

### DIFF
--- a/src/luaotfload-letterspace.lua
+++ b/src/luaotfload-letterspace.lua
@@ -335,10 +335,7 @@ kerncharacters = function (head)
         elseif pid == glue_code and kernable_skip(prev) then
           local wd   = getfield(prev, "width")
           if wd > 0 then
-            --- formula taken from Context
-            ---      existing_width extended by four times the
-            ---      width times the font’s kernfactor
-            local newwd     = wd + --[[two en to a quad]] 4 * wd * krn
+            local newwd     = wd + quaddata[lastfont] * krn
             local stretched = (getfield(prev,"stretch") * newwd) / wd
             local shrunk    = (getfield(prev,"shrink")  * newwd) / wd
             if fillup then

--- a/src/luaotfload-letterspace.lua
+++ b/src/luaotfload-letterspace.lua
@@ -93,12 +93,8 @@ local otffeatures        = fonts.constructors.newfeatures "otf"
 luaotfload.letterspace   = luaotfload.letterspace or { }
 local letterspace        = luaotfload.letterspace
 
-letterspace.keepligature = function(start)
-  local f = font.getfont(getfont(start))
-  if not f then return end
-  if not f.specification then return end
-  return not f.specification.features.normal.liga
-end
+local lectured = false
+letterspace.keepligature = true
 letterspace.keeptogether = false
 letterspace.keepwordspacing = false
 
@@ -196,6 +192,14 @@ kerncharacters = function (head)
   local lastfont      = nil
   local keeptogether  = letterspace.keeptogether --- function
   local keepligature  = letterspace.keepligature
+  if not lectured and keepligature ~= true then
+    logreport ("both", 0, "letterspace",
+               "Breaking ligatures through letterspacing is deprecated and "
+            .. "will be removed soon. Please disable unwanted ligatures through "
+            .. "font features instead and reset luaotfload.letterspace.keepligature "
+            .. "to true to maintain compatibility with future versions of luaotfload.")
+    lectured = true
+  end
   if type(keepligature) ~= "function" then
     local savedligature = keepligature
     keepligature = function() return savedligature end

--- a/src/luaotfload-letterspace.lua
+++ b/src/luaotfload-letterspace.lua
@@ -20,16 +20,14 @@ end
 --- This code diverged quite a bit from its origin in Context. Please
 --- do *not* report bugs on the Context list.
 
-local log                = luaotfload.log
-local logreport          = log.report
+local logreport          = luaotfload.log.report
 
 local getmetatable       = getmetatable
-local require            = require
 local setmetatable       = setmetatable
 local tonumber           = tonumber
 
 local next               = next
-local nodes, node, fonts = nodes, node, fonts
+local node, fonts        = node, fonts
 
 local nodedirect         = node.direct
 
@@ -74,11 +72,7 @@ local todirect           = nodedirect.todirect
 local tonode             = nodedirect.tonode
 
 local insert_node_before = nodedirect.insert_before
-local free_node          = nodedirect.free -- may cause double free
-local free_node          = function (n)
-  logreport ("term", 5, "letterspace", "not calling free_node(%d)", n)
-  -- free_node (n)
-end
+local free_node          = nodedirect.free
 local copy_node          = nodedirect.copy
 local new_node           = nodedirect.new
 
@@ -426,7 +420,7 @@ kerncharacters = function (head)
             setprev(after, tail)
             setnext(after, nil)
             post = kerncharacters (post)
-            setnext(tail, nil)
+            setnext(getprev(after), nil)
             setfield(disc, "post", post)
             free_node(after)
           end
@@ -445,7 +439,7 @@ kerncharacters = function (head)
             replace = getnext(replace)
             setprev(replace, nil)
             setnext(getprev(after), nil)
-            setfield(disc, "replace",   replace)
+            setfield(disc, "replace", replace)
             free_node(after)
             free_node(before)
 

--- a/src/luaotfload-letterspace.lua
+++ b/src/luaotfload-letterspace.lua
@@ -108,6 +108,7 @@ local letterspace        = luaotfload.letterspace
 
 letterspace.keepligature = false
 letterspace.keeptogether = false
+letterspace.keepwordspacing = false
 
 ---=================================================================---
 ---                     preliminary definitions
@@ -248,6 +249,11 @@ kerncharacters = function (head)
   local lastfont      = nil
   local keepligature  = letterspace.keepligature --- function
   local keeptogether  = letterspace.keeptogether --- function
+  local keepwordspacing = letterspace.keepwordspacing
+  if type(keepwordspacing) ~= "function" then
+    local savedwordspacing = keepwordspacing
+    keepwordspacing = function() return savedwordspacing end
+  end
   local fillup        = false
 
   local identifiers   = fonthashes.identifiers
@@ -332,7 +338,8 @@ kerncharacters = function (head)
         if not pid then
           -- nothing
 
-        elseif pid == glue_code and kernable_skip(prev) then
+        elseif pid == glue_code and kernable_skip(prev)
+                                and not keepwordspacing(prev, lastfont) then
           local wd   = getfield(prev, "width")
           if wd > 0 then
             local newwd     = wd + quaddata[lastfont] * krn

--- a/texmf/tex/luatex/luaotfload/luaotfload-letterspace.lua
+++ b/texmf/tex/luatex/luaotfload/luaotfload-letterspace.lua
@@ -335,10 +335,7 @@ kerncharacters = function (head)
         elseif pid == glue_code and kernable_skip(prev) then
           local wd   = getfield(prev, "width")
           if wd > 0 then
-            --- formula taken from Context
-            ---      existing_width extended by four times the
-            ---      width times the font’s kernfactor
-            local newwd     = wd + --[[two en to a quad]] 4 * wd * krn
+            local newwd     = wd + quaddata[lastfont] * krn
             local stretched = (getfield(prev,"stretch") * newwd) / wd
             local shrunk    = (getfield(prev,"shrink")  * newwd) / wd
             if fillup then

--- a/texmf/tex/luatex/luaotfload/luaotfload-letterspace.lua
+++ b/texmf/tex/luatex/luaotfload/luaotfload-letterspace.lua
@@ -93,12 +93,8 @@ local otffeatures        = fonts.constructors.newfeatures "otf"
 luaotfload.letterspace   = luaotfload.letterspace or { }
 local letterspace        = luaotfload.letterspace
 
-letterspace.keepligature = function(start)
-  local f = font.getfont(getfont(start))
-  if not f then return end
-  if not f.specification then return end
-  return not f.specification.features.normal.liga
-end
+local lectured = false
+letterspace.keepligature = true
 letterspace.keeptogether = false
 letterspace.keepwordspacing = false
 
@@ -196,6 +192,14 @@ kerncharacters = function (head)
   local lastfont      = nil
   local keeptogether  = letterspace.keeptogether --- function
   local keepligature  = letterspace.keepligature
+  if not lectured and keepligature ~= true then
+    logreport ("both", 0, "letterspace",
+               "Breaking ligatures through letterspacing is deprecated and "
+            .. "will be removed soon. Please disable unwanted ligatures through "
+            .. "font features instead and reset luaotfload.letterspace.keepligature "
+            .. "to true to maintain compatibility with future versions of luaotfload.")
+    lectured = true
+  end
   if type(keepligature) ~= "function" then
     local savedligature = keepligature
     keepligature = function() return savedligature end

--- a/texmf/tex/luatex/luaotfload/luaotfload-letterspace.lua
+++ b/texmf/tex/luatex/luaotfload/luaotfload-letterspace.lua
@@ -20,16 +20,14 @@ end
 --- This code diverged quite a bit from its origin in Context. Please
 --- do *not* report bugs on the Context list.
 
-local log                = luaotfload.log
-local logreport          = log.report
+local logreport          = luaotfload.log.report
 
 local getmetatable       = getmetatable
-local require            = require
 local setmetatable       = setmetatable
 local tonumber           = tonumber
 
 local next               = next
-local nodes, node, fonts = nodes, node, fonts
+local node, fonts        = node, fonts
 
 local nodedirect         = node.direct
 
@@ -74,11 +72,7 @@ local todirect           = nodedirect.todirect
 local tonode             = nodedirect.tonode
 
 local insert_node_before = nodedirect.insert_before
-local free_node          = nodedirect.free -- may cause double free
-local free_node          = function (n)
-  logreport ("term", 5, "letterspace", "not calling free_node(%d)", n)
-  -- free_node (n)
-end
+local free_node          = nodedirect.free
 local copy_node          = nodedirect.copy
 local new_node           = nodedirect.new
 
@@ -426,7 +420,7 @@ kerncharacters = function (head)
             setprev(after, tail)
             setnext(after, nil)
             post = kerncharacters (post)
-            setnext(tail, nil)
+            setnext(getprev(after), nil)
             setfield(disc, "post", post)
             free_node(after)
           end
@@ -445,7 +439,7 @@ kerncharacters = function (head)
             replace = getnext(replace)
             setprev(replace, nil)
             setnext(getprev(after), nil)
-            setfield(disc, "replace",   replace)
+            setfield(disc, "replace", replace)
             free_node(after)
             free_node(before)
 

--- a/texmf/tex/luatex/luaotfload/luaotfload-letterspace.lua
+++ b/texmf/tex/luatex/luaotfload/luaotfload-letterspace.lua
@@ -108,6 +108,7 @@ local letterspace        = luaotfload.letterspace
 
 letterspace.keepligature = false
 letterspace.keeptogether = false
+letterspace.keepwordspacing = false
 
 ---=================================================================---
 ---                     preliminary definitions
@@ -248,6 +249,11 @@ kerncharacters = function (head)
   local lastfont      = nil
   local keepligature  = letterspace.keepligature --- function
   local keeptogether  = letterspace.keeptogether --- function
+  local keepwordspacing = letterspace.keepwordspacing
+  if type(keepwordspacing) ~= "function" then
+    local savedwordspacing = keepwordspacing
+    keepwordspacing = function() return savedwordspacing end
+  end
   local fillup        = false
 
   local identifiers   = fonthashes.identifiers
@@ -332,7 +338,8 @@ kerncharacters = function (head)
         if not pid then
           -- nothing
 
-        elseif pid == glue_code and kernable_skip(prev) then
+        elseif pid == glue_code and kernable_skip(prev)
+                                and not keepwordspacing(prev, lastfont) then
           local wd   = getfield(prev, "width")
           if wd > 0 then
             local newwd     = wd + quaddata[lastfont] * krn


### PR DESCRIPTION
This makes the code slightly easier to understand by using a documented interface and is less susceptible for ConTeXt changes.
Fixes #38.

Additionally cleaning up luaotfload-letterspace.lua and migrating away from glue_specs. Support for these was dropped even before LuaTeX v1.0, so this restores letterspacing around glues.

I am not really sure how letterspacing *should* behave around spaces, so this PR just emulates what the old code would have done in old LuaTeX versions.