### PR TITLE
Less fuzzy subfamily matching

### DIFF
--- a/src/luaotfload-database.lua
+++ b/src/luaotfload-database.lua
@@ -1180,7 +1180,7 @@ lookup_font_name = function (specification)
                                                            name,
                                                            style,
                                                            askedsize)
-    if not resolved and fallback then
+    if not resolved or fallback then
         local new_resolved, new_subfont = lookup_fontname (specification,
                                                            name,
                                                            style)

--- a/texmf/tex/luatex/luaotfload/luaotfload-database.lua
+++ b/texmf/tex/luatex/luaotfload/luaotfload-database.lua
@@ -1180,7 +1180,7 @@ lookup_font_name = function (specification)
                                                            name,
                                                            style,
                                                            askedsize)
-    if not resolved and fallback then
+    if not resolved or fallback then
         local new_resolved, new_subfont = lookup_fontname (specification,
                                                            name,
                                                            style)


### PR DESCRIPTION
Only use exact matches to identify the fontstyle through the subfamily. Fixes #41. This *could* lead to some problems for legacy `afm` fonts loaded through the fontname and maybe some weird and broken OpenType fonts:
Some fonts add designsize information into the (typographic)subfamily, then the new code no longer detects them. This should no be a problem for normal fonts because their weight and slant is detected through the `tfmweight` and `italicangle` fields anyway.

We might even think about dropping the whole subfamily detection and only rely on `tfmweight` and `italicangle`, they seem much more reliable.