### PR TITLE
luaotfload-tool: support ttc fonts properly; display gsub and gpos separately

### DIFF
--- a/src/luaotfload-tool.lua
+++ b/src/luaotfload-tool.lua
@@ -628,7 +628,7 @@ local display_feature_set = function (set)
 end
 
 local display_features_type = function (id, feat)
-    if next (feat) then
+    if feat and next (feat) then
         print_heading(id, 3)
         display_feature_set(feat)
         return true
@@ -640,10 +640,11 @@ local display_features = function (features)
     texiowrite_nl ""
     print_heading("Features", 2)
 
-    if not display_features_type ("GSUB Features", features.gsub)
-    or not display_features_type ("GPOS Features", features.gpos)
-    then
-        texiowrite_nl("font defines neither gsub nor gpos features")
+    if not display_features_type ("GSUB Features", features.gsub) then
+        texiowrite_nl("font defines no gsub feature")
+    end
+    if not display_features_type ("GPOS Features", features.gpos) then
+        texiowrite_nl("font defines no gpos feature")
     end
 end
 
@@ -1188,8 +1189,8 @@ actions.query = function (job)
         end
     elseif tmpspec.lookup == "file" then
         needle  = tmpspec.name
-        subfont = tmpspec.sub
     end
+    subfont = tmpspec.sub
 
     if needle then
         foundname, _, success = fonts.names.lookup_font_file (tmpspec.name)

--- a/src/luaotfload-tool.lua
+++ b/src/luaotfload-tool.lua
@@ -640,11 +640,19 @@ local display_features = function (features)
     texiowrite_nl ""
     print_heading("Features", 2)
 
+    local status = 0
     if not display_features_type ("GSUB Features", features.gsub) then
-        texiowrite_nl("font defines no gsub feature")
+        status = status + 1
     end
     if not display_features_type ("GPOS Features", features.gpos) then
+        status = status + 2
+    end
+    if status == 3 then
+        texiowrite_nl("font defines neither gsub nor gpos features")
+    elseif status == 2 then
         texiowrite_nl("font defines no gpos feature")
+    elseif status == 1 then
+        texiowrite_nl("font defines no gsub feature")
     end
 end
 


### PR DESCRIPTION
Infomations about TTC (TrueType Collection) file, such as GillSans.ttc bundled in Mac OS X, 
can be properly displayed with this patch. 

`luaotfload-tool --find=gillsans --inspect`

The first subfont in GillSans.ttc has no GSUB info but has some GPOS info. 
To address these cases, GSUB and GPOS types are now treated separately.  

With this patch, NotoSansCJK.ttc, containing as many as 45 subfonts, is now no problem.
(On 32-bit Windows, import from _next_ release of context mkiv might be needed.)

`luaotfload-tool --find=notosanscjkkr-regular --inspect` 

