### PR TITLE
Add id parameter to patch_font callback

### DIFF
--- a/src/luaotfload-loaders.lua
+++ b/src/luaotfload-loaders.lua
@@ -138,9 +138,9 @@ do
       --- We need to test for `encodingbytes` to avoid passing
       --- tfm fonts to `patch_font`. These fonts are fragile
       --- because they use traditional TeX font handling.
-      luatexbase.call_callback ("luaotfload.patch_font", fontdata, specification)
+      luatexbase.call_callback ("luaotfload.patch_font", fontdata, specification, id)
     else
-      luatexbase.call_callback ("luaotfload.patch_font_unsafe", fontdata, specification)
+      luatexbase.call_callback ("luaotfload.patch_font_unsafe", fontdata, specification, id)
     end
     return fontdata
   end


### PR DESCRIPTION
If a callback saves information about a font to further interact with it at a later point, it might need the id. This is also useful for logging functionality.